### PR TITLE
make constructor public to prevent crashes

### DIFF
--- a/src/main/java/org/burgersim/pgeg/mixin/common/MixinManaHandler.java
+++ b/src/main/java/org/burgersim/pgeg/mixin/common/MixinManaHandler.java
@@ -26,7 +26,7 @@ public abstract class MixinManaHandler extends EntityLivingBase implements IMana
         MAX_MANA = EntityDataManager.createKey(EntityPlayer.class, DataSerializers.FLOAT);
     }
 
-    protected MixinManaHandler(EntityType<?> p_i48577_1_, World p_i48577_2_) {
+    public MixinManaHandler(EntityType<?> p_i48577_1_, World p_i48577_2_) {
         super(p_i48577_1_, p_i48577_2_);
     }
 


### PR DESCRIPTION
The constructor for MixinManaHandler was set to `protected`. This makes it inaccessible for anything trying to call the MixinManaHandler unless it's an extension of MixinManaHandler. Setting it to public prevents the game from crashing if anyone else tries to mixin to EntityLivingBase.