### PR TITLE
Fixed a crash with spell cauldron rendering due to an array being too small

### DIFF
--- a/src/main/java/org/burgersim/pgeg/client/render/TileEntitySpellCauldronRenderer.java
+++ b/src/main/java/org/burgersim/pgeg/client/render/TileEntitySpellCauldronRenderer.java
@@ -24,7 +24,7 @@ public class TileEntitySpellCauldronRenderer extends TileEntityRenderer<TileEnti
 
             float offsetPerItem = 360 / (cauldron.itemCount());
             float time = (1 - partialTicks) * cauldron.getPrevTime() + partialTicks * cauldron.getTime();
-            for (int i = 0; i < 9; i++) {
+            for (int i = 0; i < 10; i++) {
                 ItemStack stack = cauldron.getStackInSlot(i);
                 if (!stack.isEmpty()) {
                     float offset = offsetPerItem * i;

--- a/src/main/java/org/burgersim/pgeg/tileentity/TileEntitySpellCauldron.java
+++ b/src/main/java/org/burgersim/pgeg/tileentity/TileEntitySpellCauldron.java
@@ -35,7 +35,7 @@ public class TileEntitySpellCauldron extends TileEntityInventory implements ITic
     private IRecipe cachedRecipe;
 
     public TileEntitySpellCauldron() {
-        super(SPELL_CAULDRON, 9, "tile.pgeg.spell_cauldron");
+        super(SPELL_CAULDRON, 10, "tile.pgeg.spell_cauldron");
     }
 
     @Override


### PR DESCRIPTION
the array size was one too small causing a crash on rendering spell cauldron recipes